### PR TITLE
Update Trello white-paper.md

### DIFF
--- a/white-paper.md
+++ b/white-paper.md
@@ -50,9 +50,15 @@ Esse projeto é patrocinado por uma entidade, renumerando seus contribuidores co
 ## Ferramentas
 ### Codigo/Tarefas
 [Github](https://github.com/esdrasedu/ethereum_sp_dao)
+
+[Trello](https://trello.com)
+
 ### Comunicação
 [Slack](https://ethereumspdao.slack.com)
 [link invite](https://join.slack.com/t/ethereumspdao/shared_invite/enQtMzgyNDM0Nzg1MjIyLTZhMzc2ODU3NmY2Nzc3MmFiYjhhOTVjMTY2MTRkYTY3ZWFhYWRlNTlhYzU5NmQwM2IyOWY4ZDZjNDhlMTRmOWU)
+
+[Trello](https://trello.com)
+
 ### Governancia/Financeiro
 [Aragon](http://aragon.aragonpm.com/#/ethereumspdao.aragonid.eth/)
 ### Agenda


### PR DESCRIPTION
add trello.

varios projetos oficiais de criptos usam o trello:

https://trello.com/b/8L5zsyzM/bitnation-dev-internal

https://trello.com/b/aiSzWBm7/ethereum-classic-clients

https://trello.com/b/YL1qZ2pZ/brass-golem-progress-board

https://trello.com/b/Io1dDyuI/sia-feature-roadmap

quem sabe não seja util.